### PR TITLE
replace 'cf' prefixed vars

### DIFF
--- a/luceedebug/src/main/java/luceedebug/Agent.java
+++ b/luceedebug/src/main/java/luceedebug/Agent.java
@@ -12,7 +12,7 @@ public class Agent {
      * We require the following invocation
      *
      * -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=jdwpHost:1234
-     * -javaagent:/abspath/to/jarfile.jar=jdwpHost=jdwpHost,jdwpPort=1234,cfHost=cfHost,cfPort=5678,jarPath=/abspath/to/jarfile.jar
+     * -javaagent:/abspath/to/jarfile.jar=jdwpHost=jdwpHost,jdwpPort=1234,debugHost=debugHost,debugPort=5678,jarPath=/abspath/to/jarfile.jar
      * 
      * where jdwpHost and cfHost are `localhost` or `0.0.0.0` or etc.
      *
@@ -30,8 +30,8 @@ public class Agent {
         /**
          * host/port for dap connection (i.e. IDE connects to this)
          */
-        String cfHost;
-        int cfPort;
+        String debugHost;
+        int debugPort;
 
         /**
          * Path to "this" jar, as in, the Jar that contains this Agent
@@ -44,8 +44,8 @@ public class Agent {
         AgentArgs(String argString) {
             boolean gotJdwpHost = false;
             boolean gotJdwpPort = false;
-            boolean gotCfHost = false;
-            boolean gotCfPort = false;
+            boolean gotDebugHost = false;
+            boolean gotDebugPort = false;
             boolean gotJarPath = false;
 
             for (var eachArg : argString.split(",")) {
@@ -63,9 +63,11 @@ public class Agent {
                         gotJdwpHost = true;
                         break;    
                     }
-                    case "cfhost": {
-                        cfHost = value;
-                        gotCfHost = true;
+                    case "cfhost":
+                        // fallthrough (cfhost is deprecated in favor of debughost)
+                    case "debughost": {
+                        debugHost = value;
+                        gotDebugHost = true;
                         break;
                     }
                     case "jdwpport": {
@@ -78,13 +80,15 @@ public class Agent {
                         }
                         break;
                     }
-                    case "cfport": {
+                    case "cfport":
+                        // fallthrough (cfport is deprecated in favor of debugport)
+                    case "debugport": {
                         try {
-                            cfPort = Integer.parseInt(value);
-                            gotCfPort = true;
+                            debugPort = Integer.parseInt(value);
+                            gotDebugPort = true;
                         }
                         catch (NumberFormatException e) {
-                            throw new IllegalArgumentException("Invalid cfPort value in agent args string (got '" + value + "' but expected an integer).");
+                            throw new IllegalArgumentException("Invalid debugPort value in agent args string (got '" + value + "' but expected an integer).");
                         }
                         break;
                     }
@@ -104,17 +108,17 @@ public class Agent {
                     doThrow = true;
                     errMsg.append(" jdwphost");
                 }
-                if (!gotCfHost) {
+                if (!gotDebugHost) {
                     doThrow = true;
-                    errMsg.append(" cfhost");
+                    errMsg.append(" debughost");
                 }
                 if (!gotJdwpPort) {
                     doThrow = true;
                     errMsg.append(" jdwpport");
                 }
-                if (!gotCfPort) {
+                if (!gotDebugPort) {
                     doThrow = true;
-                    errMsg.append(" cfport");
+                    errMsg.append(" debugport");
                 }
                 if (!gotJarPath) {
                     doThrow = true;
@@ -165,7 +169,7 @@ public class Agent {
                 })
                 .toArray(size -> new ClassInjection[size]);
 
-            inst.addTransformer(new LuceeTransformer(classInjections, parsedArgs.jdwpHost, parsedArgs.jdwpPort, parsedArgs.cfHost, parsedArgs.cfPort));
+            inst.addTransformer(new LuceeTransformer(classInjections, parsedArgs.jdwpHost, parsedArgs.jdwpPort, parsedArgs.debugHost, parsedArgs.debugPort));
         }
         catch (Throwable e) {
             e.printStackTrace();

--- a/luceedebug/src/main/java/luceedebug/ILuceeVm.java
+++ b/luceedebug/src/main/java/luceedebug/ILuceeVm.java
@@ -5,7 +5,7 @@ import java.util.function.Consumer;
 
 import com.sun.jdi.*;
 
-public interface ICfVm {
+public interface ILuceeVm {
     public void registerStepEventCallback(Consumer</*threadID*/Long> cb);
     public void registerBreakpointEventCallback(BiConsumer</*threadID*/Long, /*bpID*/Integer> cb);
 

--- a/luceedebug/src/main/java/luceedebug/IPathTransform.java
+++ b/luceedebug/src/main/java/luceedebug/IPathTransform.java
@@ -2,12 +2,12 @@ package luceedebug;
 
 import java.util.Optional;
 
-interface ICfPathTransform {
+interface IPathTransform {
     
     /** empty if no match, never null */
-    public Optional<String> cfToIde(String s);
+    public Optional<String> serverToIde(String s);
     /** empty if no match, never null */
-    public Optional<String> ideToCf(String s);
+    public Optional<String> ideToServer(String s);
 
     /**
      * like toString, but contractually for trace purposes

--- a/luceedebug/src/main/java/luceedebug/IdentityPathTransform.java
+++ b/luceedebug/src/main/java/luceedebug/IdentityPathTransform.java
@@ -2,9 +2,9 @@ package luceedebug;
 
 import java.util.Optional;
 
-class IdentityPathTransform implements ICfPathTransform {
-    public Optional<String> cfToIde(String s) { return Optional.of(s); }
-    public Optional<String> ideToCf(String s) { return Optional.of(s); }
+class IdentityPathTransform implements IPathTransform {
+    public Optional<String> serverToIde(String s) { return Optional.of(s); }
+    public Optional<String> ideToServer(String s) { return Optional.of(s); }
 
     public String asTraceString() {
         return "IdentityPathTransform";

--- a/luceedebug/src/main/java/luceedebug/LuceeTransformer.java
+++ b/luceedebug/src/main/java/luceedebug/LuceeTransformer.java
@@ -17,8 +17,8 @@ public class LuceeTransformer implements ClassFileTransformer {
 
     private final String jdwpHost;
     private final int jdwpPort;
-    private final String cfHost;
-    private final int cfPort;
+    private final String debugHost;
+    private final int debugPort;
 
     static public class ClassInjection {
         final String name;
@@ -40,15 +40,15 @@ public class LuceeTransformer implements ClassFileTransformer {
         ClassInjection[] injections,
         String jdwpHost,
         int jdwpPort,
-        String cfHost,
-        int cfPort
+        String debugHost,
+        int debugPort
     ) {
         this.pendingCoreLoaderClassInjections = injections;
 
         this.jdwpHost = jdwpHost;
         this.jdwpPort = jdwpPort;
-        this.cfHost = cfHost;
-        this.cfPort = cfPort;
+        this.debugHost = debugHost;
+        this.debugPort = debugPort;
     }
 
     public byte[] transform(ClassLoader loader,
@@ -84,7 +84,7 @@ public class LuceeTransformer implements ClassFileTransformer {
                     System.out.println("[luceedebug] Loaded " + klass + " with ClassLoader '" + klass.getClassLoader() + "'");
                     klass
                         .getMethod("spawnWorker", String.class, int.class, String.class, int.class)
-                        .invoke(null, jdwpHost, jdwpPort, cfHost, cfPort);
+                        .invoke(null, jdwpHost, jdwpPort, debugHost, debugPort);
                 }
                 catch (Throwable e) {
                     e.printStackTrace();
@@ -148,7 +148,7 @@ public class LuceeTransformer implements ClassFileTransformer {
         var classWriter = new ClassWriter(/*ClassWriter.COMPUTE_FRAMES |*/ ClassWriter.COMPUTE_MAXS);
 
         try {
-            var instrumenter = new luceedebug.instrumenter.PageContextImpl(Opcodes.ASM9, classWriter, jdwpHost, jdwpPort, cfHost, cfPort);
+            var instrumenter = new luceedebug.instrumenter.PageContextImpl(Opcodes.ASM9, classWriter, jdwpHost, jdwpPort, debugHost, debugPort);
             var classReader = new ClassReader(classfileBuffer);
 
             classReader.accept(instrumenter, ClassReader.EXPAND_FRAMES);

--- a/luceedebug/src/main/java/luceedebug/PrefixPathTransform.java
+++ b/luceedebug/src/main/java/luceedebug/PrefixPathTransform.java
@@ -2,24 +2,24 @@ package luceedebug;
 
 import java.util.Optional;
 
-class PrefixPathTransform implements ICfPathTransform {
+class PrefixPathTransform implements IPathTransform {
     private final String idePrefix_;
-    private final String cfPrefix_;
-    public PrefixPathTransform(String idePrefix, String cfPrefix) {
+    private final String serverPrefix_;
+    public PrefixPathTransform(String idePrefix, String serverPrefix) {
         this.idePrefix_ = idePrefix;
-        this.cfPrefix_ = cfPrefix;
+        this.serverPrefix_ = serverPrefix;
     }
-    public Optional<String> cfToIde(String s) {
-        if (s.startsWith(cfPrefix_)) {
-            return Optional.of(s.replace(cfPrefix_, idePrefix_));
+    public Optional<String> serverToIde(String s) {
+        if (s.startsWith(serverPrefix_)) {
+            return Optional.of(s.replace(serverPrefix_, idePrefix_));
         }
         else {
             return Optional.empty();
         }
     }
-    public Optional<String> ideToCf(String s) {
+    public Optional<String> ideToServer(String s) {
         if (s.startsWith(idePrefix_)) {
-            return Optional.of(s.replace(idePrefix_, cfPrefix_));
+            return Optional.of(s.replace(idePrefix_, serverPrefix_));
         }
         else {
             return Optional.empty();
@@ -27,6 +27,6 @@ class PrefixPathTransform implements ICfPathTransform {
     }
 
     public String asTraceString() {
-        return "PrefixPathTransform{idePrefix='" + idePrefix_ + "', cfPrefix='" + cfPrefix_ + "'}";
+        return "PrefixPathTransform{idePrefix='" + idePrefix_ + "', serverPrefix='" + serverPrefix_ + "'}";
     }
 }

--- a/luceedebug/src/main/java/luceedebug/coreinject/DebugManager.java
+++ b/luceedebug/src/main/java/luceedebug/coreinject/DebugManager.java
@@ -6,18 +6,13 @@ import com.sun.jdi.VirtualMachine;
 
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Stack;
 import java.lang.ref.Cleaner;
-import java.lang.ref.WeakReference;
 
-import lucee.runtime.type.Collection;
 import lucee.runtime.PageContext;
-import lucee.runtime.type.scope.Scope;
 import luceedebug.DapServer;
-import lucee.runtime.PageContext;
 import lucee.runtime.PageContextImpl; // compiles fine, but IDE says it doesn't resolve
 
 import luceedebug.*;
@@ -28,18 +23,18 @@ public class DebugManager {
      * called from instrumented PageContextImpl
      */
     @SuppressWarnings("unused")
-    static public void spawnWorker(String jdwpHost, int jdwpPort, String cfHost, int cfPort) {
+    static public void spawnWorker(String jdwpHost, int jdwpPort, String debugHost, int debugPort) {
         System.out.println("[luceedebug] instrumented PageContextImpl <clinit> called spawnWorker...");
         final String threadName = "luceedebug-worker";
 
         System.out.println("[luceedebug] attempting jdwp self connect to jdwp on " + jdwpHost + ":" + jdwpPort + "...");
 
         VirtualMachine vm = jdwpSelfConnect(jdwpHost, jdwpPort);
-        CfVm cfvm = new CfVm(vm);
+        LuceeVm luceeVm = new LuceeVm(vm);
 
         new Thread(() -> {
             System.out.println("[luceedebug] jdwp self connect OK");
-            DapServer.createForSocket(cfvm, cfHost, cfPort);
+            DapServer.createForSocket(luceeVm, debugHost, debugPort);
         }, threadName).start();
     }
 

--- a/luceedebug/src/main/java/luceedebug/coreinject/LuceeVm.java
+++ b/luceedebug/src/main/java/luceedebug/coreinject/LuceeVm.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -25,7 +24,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import luceedebug.*;
 
-public class CfVm implements ICfVm {
+public class LuceeVm implements ILuceeVm {
     // This is a key into a map stored on breakpointRequest objects; the value should always be of Integer type
     // "step finalization" breakpoints will not have this, so lookup against it will yield null
     final static private String LUCEEDEBUG_BREAKPOINT_ID = "luceedebug-breakpoint-id";
@@ -241,7 +240,7 @@ public class CfVm implements ICfVm {
             request.setEnabled(true);
         }
         else if (pageRef.size() == 1) {
-            // we hoped it would be this easy, but when we initialize CfVm, lucee.runtime.Page is probably not loaded yet
+            // we hoped it would be this easy, but when we initialize LuceeVm, lucee.runtime.Page is probably not loaded yet
             bootClassTracking(pageRef.get(0));
         }
         else {
@@ -264,7 +263,7 @@ public class CfVm implements ICfVm {
     private JdwpStaticCallable bootThreadWorker() {
         JdwpWorker.touch();
 
-        final String className = "luceedebug.coreinject.CfVm$JdwpWorker";
+        final String className = "luceedebug.coreinject.LuceeVm$JdwpWorker";
         final var refs = vm_.classesByName(className);
         if (refs.size() != 1) {
             System.out.println("Expected 1 ref for class " + className + " but got " + refs.size());
@@ -308,7 +307,7 @@ public class CfVm implements ICfVm {
         return new JdwpStaticCallable(((ClassType)refType.classObject().reflectedType()), jdwp_getThread);
     }
 
-    public CfVm(VirtualMachine vm) {
+    public LuceeVm(VirtualMachine vm) {
         this.vm_ = vm;
         this.asyncWorker_.start();
         

--- a/luceedebug/src/main/java/luceedebug/instrumenter/PageContextImpl.java
+++ b/luceedebug/src/main/java/luceedebug/instrumenter/PageContextImpl.java
@@ -8,22 +8,22 @@ public class PageContextImpl extends ClassVisitor {
 
     final String jdwpHost;
     final int jdwpPort;
-    final String cfHost;
-    final int cfPort;
+    final String debugHost;
+    final int debugPort;
 
     public PageContextImpl(
         int api,
         ClassWriter cw,
         String jdwpHost,
         int jdwpPort,
-        String cfHost,
-        int cfPort
+        String debugHost,
+        int debugPort
     ) {
         super(api, cw);
         this.jdwpHost = jdwpHost;
         this.jdwpPort = jdwpPort;
-        this.cfHost = cfHost;
-        this.cfPort = cfPort;
+        this.debugHost = debugHost;
+        this.debugPort = debugPort;
     }
 
     @Override
@@ -42,8 +42,8 @@ public class PageContextImpl extends ClassVisitor {
                 protected void onMethodEnter() {
                     this.push(jdwpHost);
                     this.push(jdwpPort);
-                    this.push(cfHost);
-                    this.push(cfPort);
+                    this.push(debugHost);
+                    this.push(debugPort);
                     this.invokeStatic(Type.getType("Lluceedebug/coreinject/DebugManager;"), Method.getMethod("void spawnWorker(java.lang.String, int, java.lang.String, int)"));
                 }
             };

--- a/readme.md
+++ b/readme.md
@@ -38,16 +38,16 @@ Add the following to your java invocation. (Tomcat users can use the `setenv.sh`
 ```
 -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=localhost:9999
 
--javaagent:/abspath/to/luceedebug.jar=jdwpHost=localhost,jdwpPort=9999,cfHost=0.0.0.0,cfPort=10000,jarPath=/abspath/to/luceedebug.jar
+-javaagent:/abspath/to/luceedebug.jar=jdwpHost=localhost,jdwpPort=9999,debugHost=0.0.0.0,debugPort=10000,jarPath=/abspath/to/luceedebug.jar
 ```
 
 Most java devs will be familiar with the `agentlib` part. We need JDWP running, listening on a socket on localhost. luceedebug will attach to JDWP over a socket, running from within the same JVM. It stays attached for the life of the JVM.
 
 Note that JDWP `address` and luceedebug's `jdwpHost`/`jdwpPort` must match.
 
-The `cfPort` and `cfHost` options are the host/port that the VS Code debugger attaches to. Note that JDWP can usually listen on localhost (the connection to JDWP from luceedebug is a loopback connection).
+The `debugPort` and `debugHost` options are the host/port that the VS Code debugger attaches to. Note that JDWP can usually listen on localhost (the connection to JDWP from luceedebug is a loopback connection).
 
-If Lucee is running in a docker container, the `cfHost` must be `0.0.0.0`. However, be careful not to do this on a publicly-accessible, unprotected server, as you could expose the debugger to the public (which would be a major security vulnerability).
+If Lucee is running in a docker container, the `debugHost` must be `0.0.0.0`. However, be careful not to do this on a publicly-accessible, unprotected server, as you could expose the debugger to the public (which would be a major security vulnerability).
 
 The `jarPath` argument is the absolute path to the luceedebug.jar file. Unfortunately we have to say its name twice! One tells the JVM which jar to use as a java agent, the second is an argument to the java agent about where to find the jar it will load debugging instrumentation from.
 
@@ -123,12 +123,12 @@ A CFML debug configuration looks like:
     "pathTransforms": [
       {
         "idePrefix": "${workspaceFolder}",
-        "cfPrefix": "/app"
+        "serverPrefix": "/app"
       }
     ]
 }
 ```
-Hostname and port should match the `cfHost` and `cfPort` you've configured the java agent with.
+Hostname and port should match the `debugHost` and `debugPort` you've configured the java agent with.
 
 #### Mapping Paths with `pathTransforms`
 
@@ -140,7 +140,7 @@ Currently, it is a simple prefix replacement, e.g.:
 "pathTransforms": [
   {
     "idePrefix": "/foo",
-    "cfPrefix": "/serverAppRoot"
+    "serverPrefix": "/serverAppRoot"
   }
 ]
 ```
@@ -157,15 +157,15 @@ Example:
 "pathTransforms": [
   {
     "idePrefix": "/Users/sc/projects/subapp_b_helper",
-    "cfPrefix": "/var/www/subapp/b/helper"
+    "serverPrefix": "/var/www/subapp/b/helper"
   },
   {
     "idePrefix": "/Users/sc/projects/subapp_b",
-    "cfPrefix": "/var/www/subapp/b"
+    "serverPrefix": "/var/www/subapp/b"
   },
   {
     "idePrefix": "/Users/sc/projects/app",
-    "cfPrefix": "/var/www"
+    "serverPrefix": "/var/www"
   }
 ]
 ```

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -73,14 +73,14 @@
                     "type": "object",
                     "properties": {
                       "idePrefix": {"type": "string", "default": "${workspaceFolder}"},
-                      "cfPrefix": {"type": "string", "default": "/container-root/app"}
+                      "serverPrefix": {"type": "string", "default": "/container-root/app"}
                     },
-                    "required": ["idePrefix", "cfPrefix"]
+                    "required": ["idePrefix", "serverPrefix"]
                 },
                 "default": [
                   {
                     "idePrefix": "${workspaceFolder}",
-                    "cfPrefix": "/container-root/app"
+                    "serverPrefix": "/container-root/app"
                   }
                 ]
               }
@@ -96,7 +96,7 @@
             "pathTransforms": [
               {
                 "idePrefix": "${workspaceFolder}",
-                "cfPrefix": "/app"
+                "serverPrefix": "/app"
               }
             ],
             "port": 8000


### PR DESCRIPTION
Fixes #6

Deprecates the `cf` variable names (but allows them, for backwards-compatibility).
