### PR TITLE
Avoid throw when session management is not enabled

### DIFF
--- a/luceedebug/src/main/java/luceedebug/coreinject/DebugFrame.java
+++ b/luceedebug/src/main/java/luceedebug/coreinject/DebugFrame.java
@@ -94,7 +94,7 @@ public class DebugFrame implements IDebugFrame {
             this.form        = getScopeOrNull(() -> pageContext.formScope());
             this.local       = getScopeOrNull(() -> pageContext.localScope());
             this.request     = getScopeOrNull(() -> pageContext.requestScope());
-            this.session     = getScopeOrNull(() -> pageContext.sessionScope());
+            this.session     = getScopeOrNull(() -> pageContext.getApplicationContext().isSetSessionManagement() == true ? pageContext.sessionScope() : null);
             this.server      = getScopeOrNull(() -> pageContext.serverScope());
             this.url         = getScopeOrNull(() -> pageContext.urlScope());
             this.variables   = getScopeOrNull(() -> pageContext.variablesScope());


### PR DESCRIPTION
Avoids exceptions as described in #35 by using the `isSetSessionManagement` method documented in the [lucee javadocs](https://javadoc.lucee.org/lucee/runtime/listener/ApplicationContext.html#isSetSessionManagement()).

I was not able to test wether this works when session management is enabled since we have it explicitely disabled.