### PR TITLE
Enable VS Code hover evaluation when debugging

### DIFF
--- a/luceedebug/src/main/java/luceedebug/DapServer.java
+++ b/luceedebug/src/main/java/luceedebug/DapServer.java
@@ -173,6 +173,7 @@ public class DapServer implements IDebugProtocolServer {
     @Override
     public CompletableFuture<Capabilities> initialize(InitializeRequestArguments args) {
         var c = new Capabilities();
+        c.setSupportsEvaluateForHovers(true);
         c.setSupportsConfigurationDoneRequest(true);
         c.setSupportsSingleThreadExecutionRequests(true); // but, vscode does not (from the stack frame panel at least?)
 

--- a/vscode-client/src/extension.ts
+++ b/vscode-client/src/extension.ts
@@ -128,8 +128,8 @@ export function activate(context: vscode.ExtensionContext) {
 			 * "somestring.that.looks.like[a]variable" -> somestring.that.looks.like[a]variable
 			 * 
 			 */
-			let varRange = document.getWordRangeAtPosition(position, /[\w_][\w\[\]"'\._\-]+[\w\]]/ig);
-			varRange ??= document.getWordRangeAtPosition(position);
+			const varRange = document.getWordRangeAtPosition(position, /[\w_][\w\[\]"'\._\-]+[\w\]]/ig) 
+								?? document.getWordRangeAtPosition(position);
 			if(varRange !== undefined) {
 				return new vscode.EvaluatableExpression(varRange);
 			}


### PR DESCRIPTION
This commit adds functionality to display the variable contents when hovering over the names.
I find it easier than setting up watches when step debugging.

This example shows hovering over an entire struct:
![Screenshot 2023-09-21 160859](https://github.com/softwareCobbler/luceedebug/assets/6516640/eeeb0d0c-1683-4c82-8302-1394c9a8f8d5)

and this for a struct key access:
![Screenshot 2023-09-21 160920](https://github.com/softwareCobbler/luceedebug/assets/6516640/4b4d15b1-62d0-47d8-aaff-060ded2f984d)

It could use some polishing in determining what to show (e.g hovering over local. should show local scope, local.theData should show the struct etc) as well as ironing out the kinks I mentioned in the function comment.

Tested against the most recent Lucee 5.3 and 5.4 releases.