### PR TITLE
Fix 'e' variable being clobbered by watch exception

### DIFF
--- a/luceedebug/src/main/java/luceedebug/coreinject/ExprEvaluator.java
+++ b/luceedebug/src/main/java/luceedebug/coreinject/ExprEvaluator.java
@@ -43,12 +43,13 @@ class ExprEvaluator {
         // At this time, `lucee.runtime.compiler.Renderer.loadPage` will
         // cache compilations based on the hash of the source text; so, using the same result name
         // every time ensures we don't need to recompile a particular expression every time.
+        static protected final String errName = "__luceedebug__error";
         static protected final String resultName = "__luceedebug__evalResult";
         static protected String getEvaluatableSourceText(String expr) {
             return ""
                 + "<cfscript>"
                 + "try { variables['" + resultName + "'] = {'ok': true, 'result': " + expr + " } }"
-                + "catch (any e) { variables['" + resultName + "'] = {'ok': false, 'result': e.message } }"
+                + "catch (any " + errName + ") { variables['" + resultName + "'] = {'ok': false, 'result': " + errName + ".message } }"
                 + "</cfscript>";
         }
 

--- a/luceedebug/src/test/java/luceedebug/EvaluatesAnExpression.java
+++ b/luceedebug/src/test/java/luceedebug/EvaluatesAnExpression.java
@@ -66,7 +66,7 @@ class EvaluatesAnExpression {
             DapUtils.attach(dapServer).join();
 
             DapUtils
-                .setBreakpoints(dapServer, "/var/www/a.cfm", 3)
+                .setBreakpoints(dapServer, "/var/www/a.cfm", 4)
                 .join();
 
             final var requestThreadToBeBlockedByBreakpoint = new java.lang.Thread(() -> {
@@ -104,6 +104,21 @@ class EvaluatesAnExpression {
                 "evaluation result as expected"
             );
             
+            assertEquals(
+                "\"bar\"",
+                DapUtils.evaluate(dapServer, frameID, "e").join().getResult(),
+                "e is initialized to \"bar\""
+            );
+
+            // An expression that will throw an exception, should not clobber "e" in the local scope
+            DapUtils.evaluate(dapServer, frameID, "zzz");
+
+            assertEquals(
+                "\"bar\"",
+                DapUtils.evaluate(dapServer, frameID, "e").join().getResult(),
+                "e is still \"bar\""
+            );
+
             DapUtils.continue_(dapServer, threadID);
             
             requestThreadToBeBlockedByBreakpoint.join();

--- a/test/docker/app1/a.cfm
+++ b/test/docker/app1/a.cfm
@@ -1,5 +1,6 @@
 <cfscript>
     function foo(n) {
+        var e = "bar";
         return n;
     }
 


### PR DESCRIPTION
Fix an issue where an "e" variable in the local scope can be clobbered while line debugging.
```cfml
<cfscript>
    function foo() {
        // When debugging is enabled, "e" is clobbered by an exception in a watch expression.
        // Add watches for "zzz" and "e" to see the issue.
        var e = 1;

        // This line fails in debug mode with "variable [E] doesn't exist"
        // Add a breakpoint, then use "Run", "Step Over", or "Step Into" to see the error.
        e++;

        writeOutput(e)
    }
    foo();
</cfscript>
```

I've updated an existing test to catch this.